### PR TITLE
Ensure old sources return correct JSON structure

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rcloud.solr
 Title: Provide Solr Search and Indexing to RCloud
-Version: 0.3.1
+Version: 0.3.2
 Authors@R: person("Douglas", "Ashton", email = "dashton@mango-solutions.com", role = c("aut", "cre"))
 Description: Support solr searches and updating the index for notebooks and comments.
 Depends: R (>= 3.1.2)

--- a/R/search-source-v1.R
+++ b/R/search-source-v1.R
@@ -156,11 +156,23 @@ parse.response.high <- function(high) {
       i1 <- pmax(1, regexpr("<span ", cont) - 15)
       i2 <- pmin(nchar(cont), regexpr("span>", parts.content[[i]]$content) + 20)
       parts.content[[i]]$content <- substr(cont, i1, i2)
+
+      # Add some elements for forwards compatibility
+      parts.content[[i]]$id <- parts.content[[i]]$file
+      parts.content[[i]]$highlighting <- list(content = parts.content[[i]]$content)
+
+      if(grepl("^part", parts.content[[i]]$file))
+        parts.content[[i]]$doc_type <- "cell"
+      else if (grepl("^comment", parts.content[[i]]$file))
+        parts.content[[i]]$doc_type <- "comment"
+      else
+        parts.content[[i]]$doc_type <- "asset"
     }
 
 
   } else
-    parts.content <- list(file = "part1.R", content = "")
+    parts.content <- list(file = "part1.R", id = "part1.R", content = "", highlighting = list(content = ""))
+
 
   parts.content
 }

--- a/tests/testthat/helper-check-response.R
+++ b/tests/testthat/helper-check-response.R
@@ -1,0 +1,38 @@
+check_response_notebooks <- function(response) {
+  stopifnot(exists("matches", response))
+  stopifnot(exists("pagesize", response))
+  stopifnot(exists("n_notebooks", response))
+  if(response$matches == 0) return(TRUE)
+
+  exp_n_notebooks <- min(response$n_notebooks, response$pagesize)
+  expect_equal(length(response$notebooks), exp_n_notebooks)
+
+  for(notebook in response$notebooks) {
+    for (x in c("id", "description", "source", "starcount", "updated_at", "user", "score")) {
+      expect_true(exists(x, notebook))
+    }
+  }
+}
+
+check_response_docs <- function(response) {
+
+  # The doclists should all have a docs element
+  doclists <- lapply(response$notebooks, `[[`, "doclist")
+  for (dl in doclists) {
+    expect_true(exists("docs", dl))
+  }
+
+  # Get the docs and flatten
+  docs <- do.call("c", lapply(doclists, `[[`, "docs"))
+  for (doc in docs) {
+    check_response_one_doc(doc)
+  }
+}
+
+check_response_one_doc <- function(doc) {
+
+  for (x in c("id", "doc_type", "filename", "highlighting")) {
+    expect_true(exists(x, doc), info = paste(x, "missing from doc"))
+  }
+  expect_true(exists("content", doc$highlighting))
+}

--- a/tests/testthat/test-searchcontroller.R
+++ b/tests/testthat/test-searchcontroller.R
@@ -185,6 +185,8 @@ test_that("Full search two sources", {
   # Check the sort order (roughly)
   expect_gte(response$notebooks[[1]]$starcount,
              response$notebooks[[2]]$starcount)
+
+  check_response_docs(response)
 })
 
 
@@ -209,5 +211,7 @@ test_that("Two mixed sources", {
   )
 
   expect_equal(response$n_notebooks, 24)
+
+  check_response_docs(response)
 
 })


### PR DESCRIPTION
Fixes #71 

The response structure for version 1 was indeed out of date. Stricter tests added to enforce response structure along with the fix.