### PR TITLE
code is text_general field. See att/rcloud#2547

### DIFF
--- a/inst/solr/schema.xml
+++ b/inst/solr/schema.xml
@@ -34,7 +34,7 @@
 <field name="raw_url" type="text_general" indexed="true" stored="true"/>
 <field name="size" type="int" indexed="false" stored="true"/>
 <field name="content" type="text_general" indexed="true" stored="true" multiValued="true"/>
-<field name="code" type="string" indexed="true" stored="true" multiValued="false" />    
+<field name="code" type="text_general" indexed="true" stored="true" multiValued="false" />    
 </fields>
 
 <uniqueKey>id</uniqueKey>


### PR DESCRIPTION
This is just to keep the rcloud.solr version of the schema in sync with rcloud. Will think about making this *the* location in future.